### PR TITLE
Provide path to amsterdam.github.io

### DIFF
--- a/_includes/footer.liquid
+++ b/_includes/footer.liquid
@@ -7,13 +7,15 @@
       <a href="{{ site.baseurl }}/">Home</a>
     </li>
   </ul>
-  <p>Thanks for contributing!</p>
 </article>
 <article>
   <h3>
-    <a href="mailto:algemeen.ois@amsterdam.nl">Contact</a>
+    Contact
   </h3>
   <ul>
+    <li>
+      <a href="http://amsterdam.github.io">Amsterdam Open Source</a>
+    </li>
     <li>
       <a href="http://data.amsterdam.nl">data.amsterdam.nl</a>
     </li>

--- a/_includes/top-nav.liquid
+++ b/_includes/top-nav.liquid
@@ -1,5 +1,5 @@
 <ul>
   <li>
-    <a href="{{ site.baseurl }}/">Home</a>
+    <a href="/">Home</a>
   </li>
 </ul>


### PR DESCRIPTION
Fixes #6

How do users find their way back to Amsterdam Open Source or out of projects that have
little documentation?

I've added links to the Amsterdam Open Source website to the footer and
have the 'Home' button direct to the domain root
(often amsterdam.github.io)
as to not confuse users.

This will likely mean more projects will have to create an
`_includes/top-nav.liquid`, however that seems like a good thing.